### PR TITLE
docs: tool-driven contribution funnel + use python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,23 +8,23 @@ setup:
 test: test-all
 
 test-all:
-	python -m pytest tests/ -v
+	python3 -m pytest tests/ -v
 
 # Individual task tests
 test-task-001:
-	python -m pytest tests/test_task_001.py -v
+	python3 -m pytest tests/test_task_001.py -v
 
 test-task-002:
-	python -m pytest tests/test_task_002.py -v
+	python3 -m pytest tests/test_task_002.py -v
 
 test-task-003:
-	python -m pytest tests/test_task_003.py -v
+	python3 -m pytest tests/test_task_003.py -v
 
 test-task-004:
-	python -m pytest tests/test_task_004.py -v
+	python3 -m pytest tests/test_task_004.py -v
 
 test-task-005:
-	python -m pytest tests/test_task_005.py -v
+	python3 -m pytest tests/test_task_005.py -v
 
 # Demo
 demo:
@@ -32,9 +32,9 @@ demo:
 
 # Benchmark
 benchmark:
-	python benchmark/eval.py
+	python3 benchmark/eval.py
 
 # Lint
 lint:
-	python -m flake8 guardrails/ --max-line-length=100
-	python -m flake8 benchmark/ --max-line-length=100
+	python3 -m flake8 guardrails/ --max-line-length=100
+	python3 -m flake8 benchmark/ --max-line-length=100

--- a/README.md
+++ b/README.md
@@ -56,13 +56,20 @@ moltguard/
 
 See [AGENTS.md](AGENTS.md) for machine-readable instructions.
 
-## Contributing
+## Contributing (Tool-driven)
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We want MoltGuard to be **practical**: small guardrails, templates, and detectors you can ship quickly.
 
-### Available Tasks
+Start here: [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Pick a task from [`tasks/tasks.json`](tasks/tasks.json):
+### Pick ONE task (ship a tool)
+
+Issues (recommended entry points):
+- T-001 429 gating detection rule: https://github.com/hellojiaru/moltguard/issues/1
+- T-002 basic injection filter (patterns): https://github.com/hellojiaru/moltguard/issues/2
+- T-003 safe reply template: https://github.com/hellojiaru/moltguard/issues/3
+
+Task pool index: [`tasks/tasks.json`](tasks/tasks.json)
 
 | Task ID | Title | Time | Difficulty |
 |---------|-------|------|------------|


### PR DESCRIPTION
Tightens the contribution funnel for a tool-driven MoltGuard:
- README now points new contributors to 3 concrete tool tasks (T-001/2/3)
- Makefile uses python3 (fixes environments where `python` is not available)

Goal: improve conversion from Moltbook traffic → PRs.