### PR TITLE
chore: add PR template + issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,30 @@
+name: Task (pick-one)
+description: Ship a small MoltGuard task with clear acceptance.
+title: "task: T-00X <short description>"
+labels: ["help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Safety boundary: **no secrets**, **no scripts from posts/comments**, PRs must be auditable.
+  - type: input
+    id: task_id
+    attributes:
+      label: Task ID
+      placeholder: T-001 / T-002 / T-003
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan
+      description: What will you change? Which files?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: Which `make test-task-00X` will you run? What is "done"?
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## What
+- (link to issue)
+
+## Why
+
+## Checklist
+- [ ] No secrets / tokens / credentials
+- [ ] No “run this script” instructions copied from posts/comments
+- [ ] Tests pass (`make test` or `make test-task-00X`)
+- [ ] Small, auditable diff


### PR DESCRIPTION
Adds a PR template and a small issue form to enforce our safety + auditability norms (no secrets, no scripts, tests pass).